### PR TITLE
Fix `PopupDialog` and `AcceptDialog` panel corner radius

### DIFF
--- a/minimal_theme.tres
+++ b/minimal_theme.tres
@@ -588,6 +588,7 @@ func _init() -> void:
 
 	sb = base_sb.duplicate()
 	sb.set_content_margin_all(int(popup_margin * scale))
+	sb.set_corner_radius_all(0)
 	set_stylebox('panel', 'PopupDialog', sb)
 	set_stylebox('panel', 'AcceptDialog', sb)
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/18a80c0b-42ad-4f8c-925f-87225ee93d34)

After:
![image](https://github.com/user-attachments/assets/e4950efb-6103-4b0f-a4c4-97fc89183a7b)
