### PR TITLE
Fix error in the Android editor

### DIFF
--- a/minimal_theme.tres
+++ b/minimal_theme.tres
@@ -970,7 +970,8 @@ func _init() -> void:
 		node_3d_editor_toolbar_margin_container.add_theme_constant_override('margin_top', int(base_margin * 0.5 * scale))
 		node_3d_editor_toolbar_margin_container.add_theme_constant_override('margin_bottom', int(base_margin * 0.5 * scale))
 
-		if Engine.get_version_info().hex >= 0x040400:
+		# GameView is not enabled in the Android editor as the Game workspace is implemented differently
+		if Engine.get_version_info().hex >= 0x040400 and not OS.has_feature('android'):
 			var game_view : Control = EditorInterface.get_base_control().find_children('', 'GameView', true, false)[0]
 			var game_view_toolbar_margin_container : Control = game_view.find_children('', 'MarginContainer', true, false)[0]
 			game_view_toolbar_margin_container.add_theme_constant_override('margin_top', int(base_margin * 0.5 * scale))


### PR DESCRIPTION
Fix an error that occurs when loading the theme in the Android editor. 
The error happens because the script looks for the `GameView` to update it. But the `GameView` is disabled in the Android editor (the Game workspace is implemented differently) and unavailable which causes the error.

The fix skips that logic when running on Android.